### PR TITLE
Preserve request scheme

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -546,10 +546,16 @@ func (p *Proxy) handle(ctx *Context, conn net.Conn, brw *bufio.ReadWriter) error
 		req.TLS = &cs
 	}
 
-	req.URL.Scheme = "http"
-	if session.IsSecure() && !p.AllowHTTP {
-		log.Infof("martian: forcing HTTPS inside secure session")
-		req.URL.Scheme = "https"
+	if req.URL.Scheme == "" {
+		req.URL.Scheme = "http"
+		if session.IsSecure() {
+			req.URL.Scheme = "https"
+		}
+	} else if req.URL.Scheme == "http" {
+		if session.IsSecure() && !p.AllowHTTP {
+			log.Infof("martian: forcing HTTPS inside secure session")
+			req.URL.Scheme = "https"
+		}
 	}
 
 	req.RemoteAddr = conn.RemoteAddr().String()


### PR DESCRIPTION
Without this patch, request scheme is always set to http, and then optionally set to https, if the connection was read from *tls.Conn. This is not correct in case the request contains the full URL including the scheme, for example the following request:

HEAD https://saucelabs.com/ HTTP/1.1
...

is downgraded from https to http, if not received form *tls.Conn.

This behaviour can be observed if Martian receives requests from another proxy that have MITMed the connection and consumed the CONNECT request. The following requests would have the https scheme, as they are coming form a MITMed connection, but since they are read by http proxy the scheme is set to http.

This patch fixes that by respecting the URL scheme if present. The original logic is applied if there is no scheme.