### PR TITLE
Add http logging modes

### DIFF
--- a/martianlog/logger.go
+++ b/martianlog/logger.go
@@ -176,13 +176,14 @@ func (l *Logger) ModifyResponse(res *http.Response) error {
 // loggerFromJSON builds a logger from JSON.
 //
 // Example JSON:
-// {
-//   "log.Logger": {
-//     "scope": ["request", "response"],
-//		 "headersOnly": true,
-//		 "decode": true
-//   }
-// }
+//
+//	{
+//	  "log.Logger": {
+//	    "scope": ["request", "response"],
+//			 "headersOnly": true,
+//			 "decode": true
+//	  }
+//	}
 func loggerFromJSON(b []byte) (*parse.Result, error) {
 	msg := &loggerJSON{}
 	if err := json.Unmarshal(b, msg); err != nil {

--- a/proxy.go
+++ b/proxy.go
@@ -691,13 +691,19 @@ type peekedConn struct {
 // be read again.
 func (c *peekedConn) Read(buf []byte) (int, error) { return c.r.Read(buf) }
 
+const RoundTripDurationKey = "round-trip-duration"
+
 func (p *Proxy) roundTrip(ctx *Context, req *http.Request) (*http.Response, error) {
 	if ctx.SkippingRoundTrip() {
 		log.Debugf("martian: skipping round trip")
 		return proxyutil.NewResponse(200, nil, req), nil
 	}
 
-	return p.roundTripper.RoundTrip(req)
+	t0 := time.Now()
+	res, err := p.roundTripper.RoundTrip(req)
+	ctx.Set(RoundTripDurationKey, time.Now().Sub(t0))
+
+	return res, err
 }
 
 func (p *Proxy) warning(h http.Header, err error) {


### PR DESCRIPTION
This patch adds new http log modes 

UrlLogMode          - logs only status code and duration of a round trip.
HeadersLogMode - logs requests and responses with their headers.
BodyLogMode      - logs requests and responses with whole bodies.
ErrOnlyLogMode  - logs requests and responses with status code >= 400.